### PR TITLE
Changes to override moveValue for half moves

### DIFF
--- a/server.py
+++ b/server.py
@@ -42,7 +42,8 @@ def wrangle_move_objects_1Player(position_data):
             # Set moveValue to win, lose, or tie based on how we want to color the move buttons.
             # Moves that reduce remoteness should be green. Moves that increase remoteness should
             # be red. Moves that neither reduce nor increase remoteness should be yellow.
-            move_obj['moveValue'] = Value.WIN if delta_remoteness > 0 else Value.LOSE if delta_remoteness < 0 else Value.TIE
+            if 'moveValue' not in move_obj:
+                move_obj['moveValue'] = Value.WIN if delta_remoteness > 0 else Value.LOSE if delta_remoteness < 0 else Value.TIE
     move_objs.sort(key=key_move_obj_by_move_value_then_delta_remoteness)
 
 def wrangle_move_objects_2Player(position_data):


### PR DESCRIPTION
moveValue can be overridden with this change, mainly due to the fact that half moves can have complicated moveValue calculations that do not exactly depend on delta_remoteness. 