### PR TITLE
flowfree: register game with variants a-f, arrows above dots with source clip

### DIFF
--- a/games/__init__.py
+++ b/games/__init__.py
@@ -279,6 +279,19 @@ games = {
         },
         gui='v3'),
 
+    'flowfree': Game(
+        name='FlowFree',
+        variants={
+            variant_id: Variant(
+                name=f'Puzzle {variant_id.upper()}',
+                data_provider=GamesmanPy,
+                data_provider_game_id='flowfree',
+                data_provider_variant_id=variant_id,
+                gui='v3') for variant_id in ['a', 'b', 'c', 'd', 'e', 'f']
+        },
+        is_two_player_game=False,
+        gui='v3'),
+
     'clocksolitaire': Game(
         name='Clock Solitaire',
         variants= {

--- a/games/__init__.py
+++ b/games/__init__.py
@@ -279,19 +279,6 @@ games = {
         },
         gui='v3'),
 
-    'flowfree': Game(
-        name='FlowFree',
-        variants={
-            variant_id: Variant(
-                name=f'Puzzle {variant_id.upper()}',
-                data_provider=GamesmanPy,
-                data_provider_game_id='flowfree',
-                data_provider_variant_id=variant_id,
-                gui='v3') for variant_id in ['a', 'b', 'c', 'd', 'e', 'f']
-        },
-        is_two_player_game=False,
-        gui='v3'),
-
     'clocksolitaire': Game(
         name='Clock Solitaire',
         variants= {
@@ -531,6 +518,19 @@ games = {
                 data_provider_variant_id=2,
                 gui='v3')
         },
+        gui='v3'),
+
+    'flowfree': Game(
+        name='FlowFree',
+        variants={
+            variant_id: Variant(
+                name=f'Puzzle {variant_id.upper()}',
+                data_provider=GamesmanPy,
+                data_provider_game_id='flowfree',
+                data_provider_variant_id=variant_id,
+                gui='v3') for variant_id in ['a', 'b', 'c', 'd', 'e', 'f']
+        },
+        is_two_player_game=False,
         gui='v3'),
 
     'fourfieldkono': Game(

--- a/games/image_autogui_data.py
+++ b/games/image_autogui_data.py
@@ -875,6 +875,30 @@ def get_fivefieldkono(variant_id):
         }
     }
 
+def get_flowfree(variant_id):
+    return {
+        "defaultTheme": "regular",
+        "themes": {
+            "regular": {
+                "space": [5, 5],
+                "centers": [[0.5 + i % 5, 0.5 + i // 5] for i in range(25)],
+                "background": "flowfree/grid.svg",
+                "charImages": {
+                    "1": {"image": "general/teal_circle.svg",   "scale": 0.8},
+                    "2": {"image": "general/orange_circle.svg", "scale": 0.8},
+                    "3": {"image": "general/purple_circle.svg", "scale": 0.8},
+                    "4": {"image": "general/pink_circle.svg",   "scale": 0.8},
+                    "5": {"image": "general/brown_circle.svg",  "scale": 0.8},
+                },
+                "arrowWidth": 0.15,
+                "entitiesOverArrows": False,
+                "arrowClipSource": True,
+                "sounds": {"x": "general/place.mp3"},
+                "animationType": "entityFade",
+            }
+        }
+    }
+
 def get_fourfieldkono(variant_id):
     return {
         "defaultTheme": "basic",
@@ -2769,6 +2793,7 @@ image_autogui_data_funcs = {
     "euclidsgame": get_euclidsgame,
     "expantix": get_expantix,
     "fivefieldkono": get_fivefieldkono,
+    "flowfree": get_flowfree,
     "fourfieldkono": get_fourfieldkono,
     "forestfox": get_forestfox,
     "foxandhounds": get_foxandhounds,


### PR DESCRIPTION
## Summary

- **FlowFree registration**: register game with variants a–f backed by GamesmanPy; theme uses arrowClipSource so arrowhead covers destination dot while source dot stays on top
